### PR TITLE
Scrollbars removed 

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         </ul>
       </div>
     </div>
-    <div class="main-container">
+    <div class="main-container container-fluid h-100">
       <div class="time" id="current-time"></div>
       <div class="message" id="greeting-message"></div>
       <div class="todo" id="todo-container">


### PR DESCRIPTION
## Description
The scrollbars where removed setting the  class of the container to container-fluid and h-100


## Issue No.: #70 

> Remove the scrollbar from the extension homepage. Keep responsive to the display size.


 <strong>Please let me know if something is wrong. </strong>

## Preview
![file](https://user-images.githubusercontent.com/53908888/94887547-39d8f200-043c-11eb-8941-080b2d7bd915.jpg)

