### PR TITLE
Changed the width property of main-container.

### DIFF
--- a/static/style/style.css
+++ b/static/style/style.css
@@ -28,7 +28,7 @@ body {
   z-index: 5;
   display: flex;
   padding: 7% 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   color: white;
   justify-content: space-between;


### PR DESCRIPTION
100vw doesnt include the width of the vertical scrollbar, hence causes overflow in the x-direction. Changing it to 100% so that the container fills remaining area after vertical scrollbar comes into picture.